### PR TITLE
axi_vga_fetcher: Fix AXI Ax PROT to issue secure accesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
   check-verilog:
     name: Check Verilog sources
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       VERIBLE_VERSION: 0.0-807-g10e7c71
     steps:

--- a/src/axi_vga_fetcher.sv
+++ b/src/axi_vga_fetcher.sv
@@ -108,7 +108,6 @@ module axi_vga_fetcher #(
     axi_req.ar.burst  = 2'b01;    // Increasing burst
     axi_req.ar.cache  = 4'b0010;
     axi_req.ar.id     = '0;       // Explicitely state that we're using ID 0
-    axi_req.ar.prot   = 3'b010;
     axi_req.ar.size   = AXIStrbWidthClog2[2:0];
     axi_req.ar_valid  = 1'b0;
 


### PR DESCRIPTION
Set AxPROT = '0 to issue unprivileged, secure data accesses. Non-secure accesses can cause issues with non-PULP AXI IPs (e.g. Xilinx ZYNQ).